### PR TITLE
Fix typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
-9### CMake template
+
+### CMake template
 example/libraries
 example/build
 deps/


### PR DESCRIPTION
Looks like there's a typo in .gitignore for the main project template - kind of harmless anyway but still... :)